### PR TITLE
include stdexcept in Utilities.cpp

### DIFF
--- a/src/xmltv/Utilities.cpp
+++ b/src/xmltv/Utilities.cpp
@@ -23,6 +23,7 @@
 #include "tinyxml2.h"
 #include <algorithm>
 #include <iterator>
+#include <stdexcept>
 
 using namespace xmltv;
 


### PR DESCRIPTION

This fix compiling with GCC 4.9, fixing 36542e43f9c363916c741a0059a3d7b22d0cf1ab regression.